### PR TITLE
out_0914_fixed: memeory leak.

### DIFF
--- a/nvrom_test.c
+++ b/nvrom_test.c
@@ -94,5 +94,8 @@ int main(int argc, char **argv)
         fclose(f1);
         fclose(f2);
 
+        free(keys);
+        free(sha1_key);
+
         return 0;
 }


### PR DESCRIPTION
nvrom_test.c get memory leak.